### PR TITLE
Minimize what is imported, add Polarization enum

### DIFF
--- a/src/ITS/Propagation/LFMF/LFMF.py
+++ b/src/ITS/Propagation/LFMF/LFMF.py
@@ -78,7 +78,7 @@ def LFMF(
             c_double(d__km),
             c_double(epsilon),
             c_double(sigma),
-            c_int(pol),
+            c_int(int(pol)),
             byref(result),
         )
     )

--- a/src/ITS/Propagation/LFMF/LFMF.py
+++ b/src/ITS/Propagation/LFMF/LFMF.py
@@ -33,6 +33,11 @@ lib.LFMF.argtypes = (
 )
 
 
+class Polarization(IntEnum):
+    Horizontal = 0
+    Vertical = 1
+
+
 def LFMF(
     h_tx__meter: float,
     h_rx__meter: float,
@@ -42,7 +47,7 @@ def LFMF(
     d__km: float,
     epsilon: float,
     sigma: float,
-    pol: int,
+    pol: Polarization,
 ) -> Result:
     """
     Compute the Low Frequency / Medium Frequency (LF/MF) propagation prediction
@@ -73,7 +78,7 @@ def LFMF(
             c_double(d__km),
             c_double(epsilon),
             c_double(sigma),
-            c_int(int(pol)),
+            c_int(pol),
             byref(result),
         )
     )

--- a/src/ITS/Propagation/LFMF/__init__.py
+++ b/src/ITS/Propagation/LFMF/__init__.py
@@ -2,9 +2,4 @@
 # and Z is the version of this Python wrapper
 __version__ = "1.1.0"
 
-from .LFMF import (
-    LFMF,
-    Result,
-)
-
-__all__ = ["LFMF"]
+from .LFMF import LFMF, Result

--- a/src/ITS/Propagation/LFMF/__init__.py
+++ b/src/ITS/Propagation/LFMF/__init__.py
@@ -2,6 +2,9 @@
 # and Z is the version of this Python wrapper
 __version__ = "1.1.0"
 
-from .LFMF import *
+from .LFMF import (
+    LFMF,
+    Result,
+)
 
 __all__ = ["LFMF"]

--- a/src/ITS/Propagation/LFMF/__init__.py
+++ b/src/ITS/Propagation/LFMF/__init__.py
@@ -2,4 +2,4 @@
 # and Z is the version of this Python wrapper
 __version__ = "1.1.0"
 
-from .LFMF import LFMF, Result
+from .LFMF import LFMF, Polarization, Result


### PR DESCRIPTION
These changes ensure only the `__version__`, `LFMF` function, and `Result` structure are imported when importing this package. This avoids importing `lib` into user programs.

Also adds a `Polarization` enum which can be used to provide the polarization input. Use of the enum is not required (function behavior is unchanged)